### PR TITLE
 - Ajustes SICREDI CNAB de Pagamentos

### DIFF
--- a/src/BancoBr.CNAB/Base/Banco.cs
+++ b/src/BancoBr.CNAB/Base/Banco.cs
@@ -12,6 +12,7 @@ namespace BancoBr.CNAB.Base
         private TipoServicoEnum _tipoServico;
         private TipoLancamentoEnum _tipoLancamento;
         private LocalDebitoEnum _localDebito;
+        protected TipoServicoEnum ServicoAtual { get; private set; }
 
         protected Banco(Correntista empresa, int codigo, string nome, int versaoArquivo)
             : base(empresa, codigo, nome, versaoArquivo)
@@ -32,6 +33,8 @@ namespace BancoBr.CNAB.Base
             _tipoServico = tipoServico;
             _tipoLancamento = tipoLancamento;
             _localDebito = localDebito;
+            this.ServicoAtual = _tipoServico;
+
 
             if (tipoLancamento == TipoLancamentoEnum.CartaoSalario && tipoServico != TipoServicoEnum.PagamentoSalarios)
                 throw new InvalidOperationException("A forma de movimento Cartão Salário (4), só é permitida para o Tipo de Serviço Movimento de Salários (30)");

--- a/src/BancoBr.CNAB/Sicredi/Banco.cs
+++ b/src/BancoBr.CNAB/Sicredi/Banco.cs
@@ -42,7 +42,23 @@ namespace BancoBr.CNAB.Sicredi
             return segmento;
         }
 
-       
+        internal override RegistroDetalheBase NovoSegmentoB(TipoLancamentoEnum tipoLancamento)
+        {
+            switch (tipoLancamento)
+            {
+                case TipoLancamentoEnum.CreditoContaMesmoBanco:
+                case TipoLancamentoEnum.CreditoContaPoupancaMesmoBanco:
+                case TipoLancamentoEnum.OrdemPagamento:
+                case TipoLancamentoEnum.TEDMesmaTitularidade:
+                case TipoLancamentoEnum.TEDOutraTitularidade:
+                    return new SegmentoB_Transferencia(this);
+                case TipoLancamentoEnum.PIXTransferencia:
+                    return new SegmentoB_PIX(this);
+                default:
+                    throw new Exception("Tipo de lançamento não implementado");
+            }
+        }
+
         internal override RegistroDetalheBase PreencheSegmentoJ(RegistroDetalheBase segmento, Movimento movimento)
         {
             if (movimento.CodigoInstrucao == CodigoInstrucaoMovimentoEnum.InclusaoRegistroDetalheBloqueado) // Se o movimento for bloqueado, deve ser liberado porque a Sicredi não tem a opção 09
@@ -50,6 +66,23 @@ namespace BancoBr.CNAB.Sicredi
 
             return segmento;
         }
-        
+
+        internal override HeaderLoteBase NovoHeaderLote(TipoLancamentoEnum tipoLancamento)
+        {   
+            if (this.ServicoAtual == TipoServicoEnum.PagamentoSalarios)
+                return new HeaderLote(this);
+
+            return base.NovoHeaderLote(tipoLancamento);
+        }
+
+        internal override RegistroDetalheBase NovoSegmentoA(TipoLancamentoEnum tipoLancamento)
+        {
+            if (this.ServicoAtual == TipoServicoEnum.PagamentoSalarios)
+                return new SegmentoA_TransferenciaFolha(this);
+
+            return base.NovoSegmentoA(tipoLancamento);
+        }
+
+
     }
 }

--- a/src/BancoBr.CNAB/Sicredi/SegmentoA_TransferenciaFolha.cs
+++ b/src/BancoBr.CNAB/Sicredi/SegmentoA_TransferenciaFolha.cs
@@ -1,0 +1,34 @@
+﻿using BancoBr.Common.Attributes;
+using BancoBr.Common.Enums;
+
+namespace BancoBr.CNAB.Febraban
+{
+    public class SegmentoA_TransferenciaFolha : SegmentoA_Transferencia
+    {
+        public SegmentoA_TransferenciaFolha(Common.Instances.Banco banco)
+            : base(banco)
+        {
+        }
+
+        #region ::. Propriedades Desativadas .::
+
+        [CampoCNAB(true)]        
+        private new FinalidadeTEDEnum CodigoFinalidadeTED { get; set; }
+
+        #endregion
+
+
+        /// <summary>
+        /// Utilizando o tipo de serviço Folha de Pagamento deixar este campo em branco. 
+        /// </summary>
+
+        [CampoCNAB(220, 5)]
+        public string CodigoFinalidadeTEDBranco
+        {
+            get
+            {
+                return string.Empty; 
+            }
+        }
+    }
+}

--- a/src/BancoBr.CNAB/Sicredi/SegmentoB_Transferencia.cs
+++ b/src/BancoBr.CNAB/Sicredi/SegmentoB_Transferencia.cs
@@ -1,0 +1,34 @@
+﻿using BancoBr.Common.Attributes;
+
+namespace BancoBr.CNAB.Sicredi
+{
+    public class SegmentoB_Transferencia : Febraban.SegmentoB_Transferencia
+    {
+        public SegmentoB_Transferencia(Common.Instances.Banco banco)
+            : base(banco)
+        {
+        }
+
+        #region ::. Propriedades Desativadas .::
+
+        [CampoCNAB(true)]
+        private new int IdentificacaoBancoSPB { get; set; }
+
+        #endregion
+
+        /// <summary>
+        /// Utilizando o tipo de serviço Folha de Pagamento deixar este campo em branco. 
+        /// </summary>
+
+        [CampoCNAB(233, 8)]
+        public string IdentificacaoBancoSPBBranco
+        {
+            get
+            {
+                return string.Empty;
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
 - ajuste header lote  posição 223/230  - Utilizando o tipo de serviço Folha de Pagamento deixar este campo em branco. 
 - ajuste segmento A posição 220/224  - Utilizando o tipo de serviço Folha de Pagamento deixar este campo em branco. 
 - ajuste segmento B posição 233/240  - deverá ser enviado em branco;